### PR TITLE
Improve TEI page mapping using pdffigures2 data

### DIFF
--- a/tests/data/sample.pdffig.txt
+++ b/tests/data/sample.pdffig.txt
@@ -1,0 +1,2 @@
+Paragraph one first page.
+Paragraph two first page.Paragraph on second page.

--- a/tests/data/sample.tei.xml
+++ b/tests/data/sample.tei.xml
@@ -1,0 +1,23 @@
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <text>
+    <body>
+      <pb n="1"/>
+      <div type="section">
+        <p xml:id="p1" facs="#z1">Paragraph one first page.</p>
+        <p xml:id="p2">Paragraph two first page.</p>
+      </div>
+      <pb n="2"/>
+      <div type="section">
+        <p xml:id="p3" facs="#z2">Paragraph on second page.</p>
+      </div>
+    </body>
+    <facsimile>
+      <surface n="1">
+        <zone xml:id="z1"/>
+      </surface>
+      <surface n="2">
+        <zone xml:id="z2"/>
+      </surface>
+    </facsimile>
+  </text>
+</TEI>

--- a/tests/test_docunits_extractor.py
+++ b/tests/test_docunits_extractor.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from docunits_model import DocUnitsExtractor, SourceIds
+
+
+def test_page_mapping_with_facs_and_pdffigures():
+    extractor = DocUnitsExtractor()
+    tei = Path('tests/data/sample.tei.xml')
+    textdump = Path('tests/data/sample.pdffig.txt')
+    units = extractor.extract_from_grobid_tei(tei, 'paper1', SourceIds(), pdffigures2_textdump=textdump)
+    text_units = [u for u in units if u.type == 'text']
+    pages = [u.page for u in text_units]
+    assert pages == [1, 1, 2]


### PR DESCRIPTION
## Summary
- Map TEI paragraphs to PDF pages using `<facsimile>`/`<pb>` metadata
- Refine page detection by matching text against pdffigures2 dumps
- Add extraction test verifying page mapping

## Testing
- `pytest tests/test_docunits_extractor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b19cf74afc832b954ff2b38e29b2e0