### PR TITLE
Add configurable directories

### DIFF
--- a/directory_config.json
+++ b/directory_config.json
@@ -1,0 +1,5 @@
+{
+  "corpus_dir": "/home/ubuntu/LW_scrape/multi_source_corpus",
+  "output_dir": "/home/ubuntu/LW_scrape/scored_corpus",
+  "temp_dir": "/home/ubuntu/LW_scrape/tmp"
+}

--- a/directory_config.py
+++ b/directory_config.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from pathlib import Path
+import json
+
+CONFIG_PATH = Path(__file__).with_name('directory_config.json')
+
+@dataclass
+class DirectoryConfig:
+    corpus_dir: Path
+    output_dir: Path
+    temp_dir: Path
+
+def load_config(config_path: Path = CONFIG_PATH) -> DirectoryConfig:
+    """Load directory configuration from JSON file or provide defaults."""
+    if config_path.exists():
+        data = json.loads(config_path.read_text())
+    else:
+        data = {}
+    return DirectoryConfig(
+        corpus_dir=Path(data.get('corpus_dir', '/home/ubuntu/LW_scrape/multi_source_corpus')),
+        output_dir=Path(data.get('output_dir', '/home/ubuntu/LW_scrape/scored_corpus')),
+        temp_dir=Path(data.get('temp_dir', '/home/ubuntu/LW_scrape/tmp')),
+    )

--- a/multi_source_corpus_builder.py
+++ b/multi_source_corpus_builder.py
@@ -22,13 +22,23 @@ import openreview
 from datasketch import MinHash, MinHashLSH
 import pandas as pd
 
+from directory_config import load_config
+
 # Setup logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
+config = load_config()
+
+
 class MultiSourceCorpusBuilder:
-    def __init__(self, output_dir: str = "/home/ubuntu/LW_scrape/multi_source_corpus"):
+    def __init__(self, corpus_dir: str = str(config.corpus_dir),
+                 output_dir: str = str(config.output_dir),
+                 temp_dir: str = str(config.temp_dir)):
+        self.corpus_dir = Path(corpus_dir)
         self.output_dir = Path(output_dir)
+        self.temp_dir = Path(temp_dir)
+
         self.output_dir.mkdir(exist_ok=True)
         
         # Initialize databases
@@ -464,15 +474,17 @@ class OpenReviewConnector:
 
 def main():
     parser = argparse.ArgumentParser(description="Multi-source corpus builder for AI alignment papers")
-    parser.add_argument("--output-dir", default="/home/ubuntu/LW_scrape/multi_source_corpus")
+    parser.add_argument("--corpus-dir", default=str(config.corpus_dir))
+    parser.add_argument("--output-dir", default=str(config.output_dir))
+    parser.add_argument("--temp-dir", default=str(config.temp_dir))
     parser.add_argument("--openalex-pages", type=int, default=5, help="Max pages per OpenAlex query")
     parser.add_argument("--arxiv-results", type=int, default=1000, help="Max results from arXiv")
     parser.add_argument("--openreview-limit", type=int, default=200, help="Max papers per venue from OpenReview")
     parser.add_argument("--dry-run", action="store_true", help="Skip API calls, use cached data")
-    
+
     args = parser.parse_args()
-    
-    builder = MultiSourceCorpusBuilder(args.output_dir)
+
+    builder = MultiSourceCorpusBuilder(args.corpus_dir, args.output_dir, args.temp_dir)
     
     logger.info("🚀 Starting multi-source corpus building...")
     

--- a/structured_pdf_parser.py
+++ b/structured_pdf_parser.py
@@ -355,9 +355,19 @@ class TEIParser:
         
         return '\n\n'.join(text_parts)
 
+from directory_config import load_config
+
+config = load_config()
+
+
 class StructuredPDFParser:
-    def __init__(self, corpus_dir: str = "/home/ubuntu/LW_scrape/multi_source_corpus"):
+    def __init__(self,
+                 corpus_dir: str = str(config.corpus_dir),
+                 output_dir: str = str(config.output_dir),
+                 temp_dir: str = str(config.temp_dir)):
         self.corpus_dir = Path(corpus_dir)
+        self.output_dir = Path(output_dir)
+        self.temp_dir = Path(temp_dir)
         
         # Setup directories
         self.pdf_dir = self.corpus_dir / "downloaded_papers"
@@ -375,7 +385,7 @@ class StructuredPDFParser:
         
         # Find pdffigures2 jar
         jar_paths = [
-            "/home/ubuntu/pdffigures2/target/scala-2.12/pdffigures2-assembly.jar",
+            str(Path.home() / "pdffigures2/target/scala-2.12/pdffigures2-assembly.jar"),
             "./pdffigures2/target/scala-2.12/pdffigures2-assembly.jar",
             "/usr/local/bin/pdffigures2-assembly.jar"
         ]
@@ -661,14 +671,16 @@ def main():
     import argparse
     
     parser = argparse.ArgumentParser(description="Structured PDF parsing with GROBID and pdffigures2")
-    parser.add_argument("--corpus-dir", default="/home/ubuntu/LW_scrape/multi_source_corpus")
+    parser.add_argument("--corpus-dir", default=str(config.corpus_dir))
+    parser.add_argument("--output-dir", default=str(config.output_dir))
+    parser.add_argument("--temp-dir", default=str(config.temp_dir))
     parser.add_argument("--setup-services", action="store_true", help="Setup GROBID and pdffigures2")
     parser.add_argument("--skip-grobid", action="store_true", help="Skip GROBID processing")
     parser.add_argument("--skip-pdffigures2", action="store_true", help="Skip pdffigures2 processing")
-    
+
     args = parser.parse_args()
-    
-    parser = StructuredPDFParser(args.corpus_dir)
+
+    parser = StructuredPDFParser(args.corpus_dir, args.output_dir, args.temp_dir)
     
     # Setup services if requested
     if args.setup_services:


### PR DESCRIPTION
## Summary
- centralize corpus, output, and temp directories via `directory_config`
- allow multi-source corpus builder to accept directory overrides
- parameterize multi-source-to-Wilson Lin and structured PDF parser scripts for flexible paths

## Testing
- `python -m py_compile multi_source_corpus_builder.py multisource_to_wilson_lin.py structured_pdf_parser.py directory_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68b19e7d244c832baf73e86f6e67c28a